### PR TITLE
Added Rotated MNIST dataloaders

### DIFF
--- a/data/pt_ood.py
+++ b/data/pt_ood.py
@@ -92,11 +92,7 @@ def load_rotated_dataset(
         source_dset.data = source_dset.data[subset]
         source_dset.targets = source_dset.targets[subset]
 
-    source_loader = torch.utils.data.DataLoader(
-        source_dset,
-        batch_size=batch_size, shuffle=False,
-        num_workers=num_workers)
-    # source_loader = NumpyLoader(
-    #     source_dset, batch_size=batch_size, shuffle=False, num_workers=num_workers)
+    source_loader = NumpyLoader(
+        source_dset, batch_size=batch_size, shuffle=False, num_workers=num_workers)
 
-    return source_loader
+    return source_loader, source_dset


### PR DESCRIPTION
Adding the load_rotated_dataset code, mostly unchanged from the function here. https://github.com/edaxberger/bayesian-lottery-tickets/blob/a3e67ad593b2716b6c1fac272916f887349740cc/src/evaluation/utils.py#L152

Only changes are - 

1. Replacing torch.utils.Dataloader to NumpyLoader
2. Adding ToNumpy() and MoveChannelDim() transforms